### PR TITLE
Add xml to File media type's allowed extensions.

### DIFF
--- a/config/sync/field.field.media.file.field_media_file.yml
+++ b/config/sync/field.field.media.file.field_media_file.yml
@@ -27,7 +27,7 @@ settings:
   handler: 'default:file'
   handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: 'txt rtf doc docx ppt pptx xls xlsx pdf odf odg odp ods odt fodt fods fodp fodg key numbers pages tiff tif jp2'
+  file_extensions: 'txt rtf doc docx ppt pptx xls xlsx pdf odf odg odp ods odt fodt fods fodp fodg key numbers pages tiff tif jp2 xml'
   max_filesize: ''
   description_field: false
 field_type: file


### PR DESCRIPTION
# What does this Pull Request do?

Lets you add xml files as File Media.

* **Related GitHub Issue**: https://github.com/Islandora/islandora-starter-site/issues/9

* **Other Relevant Links**: (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What's new?

* Added xml to the allowed extensions.

* Does this change add any new dependencies?  - no
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  - no
* Could this change impact execution of existing code? - no

# How should this be tested?

Create a Media that is a File media type.

Before - config does not let you add XML
After - config allows you to add XML

# Documentation Status

* Does this change existing behaviour that's currently documented? - no
* Does this change require new pages or sections of documentation? - no
* Who does this need to be documented for? - no
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
