### PR TITLE
Update composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "drush/drush": "^10.3",
         "islandora-rdm/islandora_fits": "dev-8.x-1.x as 1.x-dev",
         "islandora/controlled_access_terms": "^2",
-        "islandora/islandora": "^2.4",
+        "islandora/islandora": "^2.5",
         "islandora/openseadragon": "^2"
     },
     "conflict": {

--- a/composer.lock
+++ b/composer.lock
@@ -2166,6 +2166,100 @@
             "time": "2022-10-06T15:57:08+00:00"
         },
         {
+            "name": "drupal/ctools",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/ctools.git",
+                "reference": "4.0.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/ctools-4.0.1.zip",
+                "reference": "4.0.1",
+                "shasum": "ac2373c13efd7d95da7230bd5a6627f16a6a5b6e"
+            },
+            "require": {
+                "drupal/core": "^9.3 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "4.0.1",
+                    "datestamp": "1660252593",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "branch-alias": {
+                    "dev-4.x": "4.x-dev"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Kris Vanderwater (EclipseGc)",
+                    "homepage": "https://www.drupal.org/u/eclipsegc",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Jakob Perry (japerry)",
+                    "homepage": "https://www.drupal.org/u/japerry",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Tim Plunkett (tim.plunkett)",
+                    "homepage": "https://www.drupal.org/u/timplunkett",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "James Gilliland (neclimdul)",
+                    "homepage": "https://www.drupal.org/u/neclimdul",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Daniel Wehner (dawehner)",
+                    "homepage": "https://www.drupal.org/u/dawehner",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Joël (joelpittet)",
+                    "homepage": "https://www.drupal.org/u/joelpittet",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "merlinofchaos",
+                    "homepage": "https://www.drupal.org/user/26979"
+                },
+                {
+                    "name": "neclimdul",
+                    "homepage": "https://www.drupal.org/user/48673"
+                },
+                {
+                    "name": "sdboyer",
+                    "homepage": "https://www.drupal.org/user/146719"
+                },
+                {
+                    "name": "sun",
+                    "homepage": "https://www.drupal.org/user/54136"
+                },
+                {
+                    "name": "tim.plunkett",
+                    "homepage": "https://www.drupal.org/user/241634"
+                }
+            ],
+            "description": "Provides a number of utility and helper APIs for Drupal developers and site builders.",
+            "homepage": "https://www.drupal.org/project/ctools",
+            "support": {
+                "source": "https://git.drupalcode.org/project/ctools",
+                "issues": "https://www.drupal.org/project/issues/ctools"
+            }
+        },
+        {
             "name": "drupal/eva",
             "version": "2.1.0",
             "source": {
@@ -4598,20 +4692,21 @@
         },
         {
             "name": "islandora/islandora",
-            "version": "2.4.3",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Islandora/islandora.git",
-                "reference": "725b5592803564c9727e920b780247e45ecbc9a4"
+                "reference": "3f7ca2ca10bf5e01a9211819550321c4aad22e12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Islandora/islandora/zipball/725b5592803564c9727e920b780247e45ecbc9a4",
-                "reference": "725b5592803564c9727e920b780247e45ecbc9a4",
+                "url": "https://api.github.com/repos/Islandora/islandora/zipball/3f7ca2ca10bf5e01a9211819550321c4aad22e12",
+                "reference": "3f7ca2ca10bf5e01a9211819550321c4aad22e12",
                 "shasum": ""
             },
             "require": {
                 "drupal/context": "^4.0@beta",
+                "drupal/ctools": "^3.8 || ^4",
                 "drupal/eva": "^2.0",
                 "drupal/features": "^3.7",
                 "drupal/file_replace": "^1.1",
@@ -4661,9 +4756,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Islandora/documentation/issues",
-                "source": "https://github.com/Islandora/islandora/tree/2.4.3"
+                "source": "https://github.com/Islandora/islandora/tree/2.5.0"
             },
-            "time": "2022-08-31T22:14:12+00:00"
+            "time": "2022-11-07T13:43:38+00:00"
         },
         {
             "name": "islandora/jsonld",
@@ -11198,5 +11293,5 @@
         "php": "^7.4 || ^8"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -19,6 +19,7 @@ module:
   contextual: 0
   controlled_access_terms: 0
   controlled_access_terms_defaults: 0
+  ctools: 0
   datetime: 0
   dblog: 0
   dynamic_page_cache: 0


### PR DESCRIPTION
# What does this Pull Request do?

Updates the composer.json and composer.lock files to use islandora 2.5. This release of islandora fixes the batch upload children issue.

* **Related GitHub Issue**: 
https://github.com/Islandora/documentation/issues/2129

* **Other Relevant Links**:
https://github.com/Islandora/islandora/pull/896
https://github.com/Islandora/documentation/pull/2187

# What's new?

* Updated composer.json to require islandora 2.5
* Updated composer.lock to include ctools 4.0.1 and islandora 2.5.0
* Updated core extensions to include ctools
* Does this change add any new dependencies? Yes
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# How should this be tested?

* If using isle-dc, replace the starter site repository clone in the starter_dev function of the Makefile with this pr: git clone -b update-composer https://github.com/aOelschlager/islandora-starter-site
* Then run make starter_dev. This should give you a fresh site running islandora 2.5
* Try using the batch upload children form as directed here in the documentation pr: https://github.com/Islandora/documentation/pull/2187

# Documentation Status

* Does this change existing behaviour that's currently documented? Yes but it's a pr ready to merge. 
* Does this change require new pages or sections of documentation? No
* Who does this need to be documented for? PR documentation addresses that.
* Associated documentation pull request(s): https://github.com/Islandora/documentation/pull/2187

# Additional Notes:
I'm not sure how to test this with the playbook deployment so I didn't include those instructions in the how to test section.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
