### PR TITLE
Change the taxonomy for the Browse all Collections view

### DIFF
--- a/config/sync/context.context.collection.yml
+++ b/config/sync/context.context.collection.yml
@@ -21,7 +21,7 @@ conditions:
     negate: false
     context_mapping:
       node: '@node.node_route_context:node'
-    uri: 'http://purl.org/dc/dcmitype/Collection'
+    uri: 'http://purl.org/ontology/bibo/Collection'
     logic: and
 reactions:
   blocks:

--- a/config/sync/views.view.oai_pmh.yml
+++ b/config/sync/views.view.oai_pmh.yml
@@ -162,7 +162,7 @@ display:
           admin_label: ''
           plugin_id: string
           operator: '!='
-          value: 'http://purl.org/dc/dcmitype/Collection'
+          value: 'http://purl.org/ontology/bibo/Collection'
           group: 1
           exposed: false
           expose:
@@ -363,7 +363,7 @@ display:
           admin_label: ''
           plugin_id: string
           operator: '!='
-          value: 'http://purl.org/dc/dcmitype/Collection'
+          value: 'http://purl.org/ontology/bibo/Collection'
           group: 1
           exposed: false
           expose:


### PR DESCRIPTION
# What does this Pull Request do?
Browse all collections is potentially using the wrong taxonomy authority for collections.

* **Related GitHub Issue**: N/A

* **Other Relevant Links**: 
https://islandora.slack.com/archives/CM6F4C4VA/p1669133706616649

# What's new?
Switched the authoritative URI from the DCMI Terms vocabulary

# How should this be tested?
Install and see if the browse all collections works.

# Documentation Status
N/A

# Additional Notes:
N/A

# Interested parties
@Islandora/committers
