### PR TITLE
Bartik to Olivero Facet and Search Blocks

### DIFF
--- a/config/sync/block.block.creatorsandcontributors.yml
+++ b/config/sync/block.block.creatorsandcontributors.yml
@@ -1,6 +1,6 @@
 uuid: 28540a48-a2eb-4a84-b4c9-fa9dce4c9f36
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - facets.facet.creators_and_contributors
@@ -21,7 +21,7 @@ plugin: 'facet_block:creators_and_contributors'
 settings:
   id: 'facet_block:creators_and_contributors'
   label: 'Creators and Contributors'
-  label_display: '0'
+  label_display: visible
   provider: facets
   block_id: creatorsandcontributors
 visibility:

--- a/config/sync/block.block.creatorsandcontributors.yml
+++ b/config/sync/block.block.creatorsandcontributors.yml
@@ -9,12 +9,12 @@ dependencies:
     - islandora
     - system
   theme:
-    - bartik
+    - olivero
 _core:
   default_config_hash: jziE1LayhQhICzoN5LBg3jdBwNieZWUHHr4xGAlwj_o
 id: creatorsandcontributors
-theme: bartik
-region: header
+theme: olivero
+region: sidebar
 weight: 0
 provider: null
 plugin: 'facet_block:creators_and_contributors'

--- a/config/sync/block.block.exposedformsolr_search_contentpage_1.yml
+++ b/config/sync/block.block.exposedformsolr_search_contentpage_1.yml
@@ -1,6 +1,6 @@
 uuid: 56c77381-d362-4acb-bf96-a32842a2b312
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - views.view.solr_search_content
@@ -13,7 +13,7 @@ _core:
 id: exposedformsolr_search_contentpage_1
 theme: olivero
 region: header
-weight: -5
+weight: 1
 provider: null
 plugin: 'views_exposed_filter_block:solr_search_content-page_1'
 settings:

--- a/config/sync/block.block.exposedformsolr_search_contentpage_1.yml
+++ b/config/sync/block.block.exposedformsolr_search_contentpage_1.yml
@@ -7,11 +7,11 @@ dependencies:
   module:
     - views
   theme:
-    - bartik
+    - olivero
 _core:
   default_config_hash: UGbvzHUCMdMe84lOKlLRajT3aIi2OFnAGpZw1eceoQY
 id: exposedformsolr_search_contentpage_1
-theme: bartik
+theme: olivero
 region: header
 weight: -5
 provider: null

--- a/config/sync/block.block.physicalform.yml
+++ b/config/sync/block.block.physicalform.yml
@@ -8,12 +8,12 @@ dependencies:
     - facets
     - system
   theme:
-    - bartik
+    - olivero
 _core:
   default_config_hash: Gb14JbPGc1IX6-hfhZr_EVEg-AUiYnV50EJcfUIIgHc
 id: physicalform
-theme: bartik
-region: header
+theme: olivero
+region: sidebar
 weight: 0
 provider: null
 plugin: 'facet_block:physical_form'

--- a/config/sync/block.block.physicalform.yml
+++ b/config/sync/block.block.physicalform.yml
@@ -1,6 +1,6 @@
 uuid: cbb732ca-9e8d-4597-bfd1-e81e40210010
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - facets.facet.physical_form

--- a/config/sync/block.block.subject.yml
+++ b/config/sync/block.block.subject.yml
@@ -1,6 +1,6 @@
 uuid: d5cb2c16-4125-49d7-8a52-3f493b6a1f3e
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - facets.facet.subject

--- a/config/sync/block.block.subject.yml
+++ b/config/sync/block.block.subject.yml
@@ -8,12 +8,12 @@ dependencies:
     - facets
     - system
   theme:
-    - bartik
+    - olivero
 _core:
   default_config_hash: 8CNTurKBSOQZRTrWiaCmfAwseQyzXZOb8gJohUvIBFw
 id: subject
-theme: bartik
-region: header
+theme: olivero
+region: sidebar
 weight: 0
 provider: null
 plugin: 'facet_block:subject'

--- a/config/sync/block.block.subjectname.yml
+++ b/config/sync/block.block.subjectname.yml
@@ -8,12 +8,12 @@ dependencies:
     - facets
     - system
   theme:
-    - bartik
+    - olivero
 _core:
   default_config_hash: VFNCtt7POqemCYyZ3x3gWDwdyJfoAmbqHim37oy6onU
 id: subjectname
-theme: bartik
-region: header
+theme: olivero
+region: sidebar
 weight: 0
 provider: null
 plugin: 'facet_block:subject_name'

--- a/config/sync/block.block.subjectname.yml
+++ b/config/sync/block.block.subjectname.yml
@@ -1,6 +1,6 @@
 uuid: 0834cb8f-c2e8-4edf-a811-01052043e273
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - facets.facet.subject_name

--- a/config/sync/block.block.temporalsubject.yml
+++ b/config/sync/block.block.temporalsubject.yml
@@ -8,12 +8,12 @@ dependencies:
     - facets
     - system
   theme:
-    - bartik
+    - olivero
 _core:
   default_config_hash: 1BMA18tJL_4xlrR2wg5QSmr499p157HBiWAgv_rJmQ4
 id: temporalsubject
-theme: bartik
-region: header
+theme: olivero
+region: sidebar
 weight: 0
 provider: null
 plugin: 'facet_block:temporal_subject'

--- a/config/sync/block.block.temporalsubject.yml
+++ b/config/sync/block.block.temporalsubject.yml
@@ -1,6 +1,6 @@
 uuid: 8fb0c923-1639-4314-be61-bf648dc18669
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - facets.facet.temporal_subject

--- a/config/sync/facets.facet.creators_and_contributors.yml
+++ b/config/sync/facets.facet.creators_and_contributors.yml
@@ -43,7 +43,7 @@ empty_behavior:
   behavior: none
 only_visible_when_facet_source_is_visible: true
 show_only_one_result: false
-show_title: true
+show_title: false
 processor_configs:
   active_widget_order:
     processor_id: active_widget_order


### PR DESCRIPTION
# What does this Pull Request do?

Switches facet and search blocks in the Bartik theme to the Olivero theme. Fixes some of the block displays and makes the search bar available for use.

* **Related GitHub Issue**: https://github.com/Islandora/islandora-starter-site/issues/10
https://github.com/Islandora/islandora-starter-site/issues/23

* **Other Relevant Links**: (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What's new?

* Changes facets in Bartik to Olivero and places them in the sidebar region.
* Changes  solr search content block from Bartik to Olivero.
* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? No

# How should this be tested?

* If using isle-dc, replace the starter site repository clone in the starter_dev function of the Makefile with this pr: git clone -b olivero-blocks https://github.com/aOelschlager/islandora-starter-site
* Then run make starter_dev.
* Create repository items and include terms for Creators, Physical Form, Subject, Subject (name), and Temporal Subject.
* Use the terms in the search bar and the results should show the terms in the facets.

# Documentation Status

* Does this change existing behaviour that's currently documented? No
* Does this change require new pages or sections of documentation? No
* Who does this need to be documented for? N/A
* Associated documentation pull request(s): N/A

# Additional Notes:
This pr is just using the existing configuration on the stater site with the new default theme. This does not use the advance search nor does it display a pager with grid or list views as referenced in https://github.com/Islandora/islandora-starter-site/issues/23

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
