### PR TITLE
Fix authority link migration

### DIFF
--- a/assets/migrate/tags.csv
+++ b/assets/migrate/tags.csv
@@ -1,14 +1,14 @@
-vid,name,description,external_uri
-islandora_display,"Open Seadragon","Display using the Open Seadragon viewer",http://openseadragon.github.io
-islandora_display,"PDFjs","Display using the PDF.js viewer",http://mozilla.github.io/pdf.js
-resource_types,"Collection","An aggregation of resources",http://purl.org/ontology/bibo/Collection
-resource_types,"Dataset","Data encoded in a defined structure",http://purl.org/dc/dcmitype/Dataset
-resource_types,"Image","A visual representation other than text",http://purl.org/dc/dcmitype/Image
-resource_types,"Interactive Resource","A resource requiring interaction from the user to be understood, executed, or experienced",http://purl.org/dc/dcmitype/InteractiveResource
-resource_types,"Moving Image","A series of visual representations imparting an impression of motion when shown in succession",http://purl.org/dc/dcmitype/MovingImage
-resource_types,"Physical Object","An inanimate, three-dimensional object or substance",http://purl.org/dc/dcmitype/PhysicalObject
-resource_types,"Service","A system that provides one or more functions",http://purl.org/dc/dcmitype/Service
-resource_types,"Sound","A resource primarily intended to be heard",http://purl.org/dc/dcmitype/Sound
-resource_types,"Still Image","A static visual representation",http://purl.org/dc/dcmitype/StillImage
-resource_types,"Software","A computer program in source or compiled form",http://purl.org/dc/dcmitype/Software
-resource_types,"Text","A resource consisting primarily of words for reading",http://purl.org/dc/dcmitype/Text
+vid,name,description,external_uri,authority_link_source
+islandora_display,"Open Seadragon","Display using the Open Seadragon viewer",http://openseadragon.github.io,
+islandora_display,"PDFjs","Display using the PDF.js viewer",http://mozilla.github.io/pdf.js,
+resource_types,"Collection","An aggregation of resources",http://purl.org/ontology/bibo/Collection,
+resource_types,"Dataset","Data encoded in a defined structure",http://purl.org/dc/dcmitype/Dataset,dcmi_types
+resource_types,"Image","A visual representation other than text",http://purl.org/dc/dcmitype/Image,dcmi_types
+resource_types,"Interactive Resource","A resource requiring interaction from the user to be understood, executed, or experienced",http://purl.org/dc/dcmitype/InteractiveResource,dcmi_types
+resource_types,"Moving Image","A series of visual representations imparting an impression of motion when shown in succession",http://purl.org/dc/dcmitype/MovingImage,dcmi_types
+resource_types,"Physical Object","An inanimate, three-dimensional object or substance",http://purl.org/dc/dcmitype/PhysicalObject,dcmi_types
+resource_types,"Service","A system that provides one or more functions",http://purl.org/dc/dcmitype/Service,dcmi_types
+resource_types,"Sound","A resource primarily intended to be heard",http://purl.org/dc/dcmitype/Sound,dcmi_types
+resource_types,"Still Image","A static visual representation",http://purl.org/dc/dcmitype/StillImage,dcmi_types
+resource_types,"Software","A computer program in source or compiled form",http://purl.org/dc/dcmitype/Software,dcmi_types
+resource_types,"Text","A resource consisting primarily of words for reading",http://purl.org/dc/dcmitype/Text,dcmi_types

--- a/assets/migrate/tags.csv
+++ b/assets/migrate/tags.csv
@@ -1,7 +1,7 @@
 vid,name,description,external_uri,authority_link_source
 islandora_display,"Open Seadragon","Display using the Open Seadragon viewer",http://openseadragon.github.io,
 islandora_display,"PDFjs","Display using the PDF.js viewer",http://mozilla.github.io/pdf.js,
-resource_types,"Collection","An aggregation of resources",http://purl.org/ontology/bibo/Collection,
+resource_types,"Collection","An aggregation of resources",http://purl.org/ontology/bibo/Collection,bibo
 resource_types,"Dataset","Data encoded in a defined structure",http://purl.org/dc/dcmitype/Dataset,dcmi_types
 resource_types,"Image","A visual representation other than text",http://purl.org/dc/dcmitype/Image,dcmi_types
 resource_types,"Interactive Resource","A resource requiring interaction from the user to be understood, executed, or experienced",http://purl.org/dc/dcmitype/InteractiveResource,dcmi_types

--- a/config/sync/field.field.taxonomy_term.resource_types.field_authority_link.yml
+++ b/config/sync/field.field.taxonomy_term.resource_types.field_authority_link.yml
@@ -23,6 +23,7 @@ settings:
   authority_sources:
     dcmi_types: 'DCMI Type Vocabulary'
     marc_resource_types: 'MARC Resource Types'
+    bibo: 'Bibliographic Ontology'
     other: Other
   title: 1
   link_type: 16

--- a/config/sync/migrate_plus.migration.islandora_defaults_tags.yml
+++ b/config/sync/migrate_plus.migration.islandora_defaults_tags.yml
@@ -31,8 +31,7 @@ process:
   field_authority_link/title:
     plugin: urlencode
     source: external_uri
-  field_authority_link/source:
-    source: authority_link_source
+  field_authority_link/source: authority_link_source
 destination:
   plugin: 'entity:taxonomy_term'
 migration_dependencies:

--- a/config/sync/migrate_plus.migration.islandora_defaults_tags.yml
+++ b/config/sync/migrate_plus.migration.islandora_defaults_tags.yml
@@ -25,9 +25,14 @@ process:
   field_external_uri:
     plugin: urlencode
     source: external_uri
-  field_authority_link:
+  field_authority_link/uri:
     plugin: urlencode
     source: external_uri
+  field_authority_link/title:
+    plugin: urlencode
+    source: external_uri
+  field_authority_link/source:
+    source: authority_link_source
 destination:
   plugin: 'entity:taxonomy_term'
 migration_dependencies:


### PR DESCRIPTION
# What does this Pull Request do?

The "Resource Type" terms were getting migrated along with their "external uri". However, some vocabularies (like Resource Types) don't have an "external uri" field but instead an "authority link" field. It was getting put in there - but that didn't make a complete viable field. This field has three (major) elements: uri, title, and source. All these three are visible in the GUI when editing the field and Source is mandatory. But when we migrate terms in, only the uri element is getting populated.  So when we tried to display the term- on the node page or in views - it doesn't show up at all. (also maybe later fix the Authority Link field formatter... but for now we should make right with what we've got.)

This PR updates the migration so that 
* the same URI in the uri is used as the title, since these are administrative terms and the URI needs to be legible to managers.
* The source field is populated. I added a column for that, and set all (except collection) to the DCMI terms. Collection (in Resource types) is the Bibo version. This keeps us from interfering with the Islandora Models.

**Related GitHub Issue**: 
* https://github.com/Islandora/islandora-starter-site/issues/35

* **Other Relevant Links**: (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
